### PR TITLE
优化股票插件在"显示设置"中显示股票名称

### DIFF
--- a/Plugins/Stock/StockItem.cpp
+++ b/Plugins/Stock/StockItem.cpp
@@ -12,21 +12,21 @@ const wchar_t *StockItem::GetItemName() const
 {
     static std::wstring item_name;
     auto data = g_data.GetStockData(stock_id);
-    if (data->info.is_ok)
+    if (data->info.is_ok && !data->info.displayName.empty())
     {
-        if (data)
-        {
-            item_name = data->info.displayName;
-        }
-        else
-        {
-            item_name = g_data.StringRes(IDS_PLUGIN_ITEM_NAME).GetString();
-            item_name += std::to_wstring(index);
-        }
+        // 数据加载成功且有名称，显示股票名称
+        item_name = data->info.displayName;
+    }
+    else if (!data->info.is_ok && !stock_id.empty())
+    {
+        // 加载失败，显示错误信息
+        item_name = stock_id + L" " + g_data.StringRes(IDS_LOAD_FAIL).GetString();
     }
     else
     {
-        item_name = stock_id + L" " + g_data.StringRes(IDS_LOAD_FAIL).GetString();
+        // 默认情况：显示 "股票" + index
+        item_name = g_data.StringRes(IDS_PLUGIN_ITEM_NAME).GetString();
+        item_name += std::to_wstring(index);
     }
     return item_name.c_str();
 }


### PR DESCRIPTION
  ## 改进前
  显示设置中始终显示"股票0"、"股票1"等默认名称，用户无法区分具体是哪只股票。

  ## 改进后
  显示设置中显示实际的股票名称（如"贵州茅台"），便于用户快速识别和选择。

  ## Test plan
  - [√] 添加多只股票后，在"显示设置"中确认显示各股票的实际名称
  - [√] 未配置股票时显示"股票0"
  - [√] 数据加载失败时显示错误提示